### PR TITLE
Error on empty input when `allow-empty` is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ All helpers accept the following optional named arguments (even though they are 
 | `locale` | An optional `String` [locale](https://momentjs.com/docs/#/i18n/), to override the default global `moment.locale` |
 | `timeZone` | An optional `String` [time zone](https://momentjs.com/timezone/docs/), defaults to `moment.timeZone` (the default time zone) |
 | `interval` | An optional interval `Number` of milliseconds when the helper should be recomputed |
-| `allow-empty` | An optional `Boolean` to ignore the `Invalid date` output when knowingly passing `null`, `undefined`, or `''`, defaults to `false` |
+| `allow-empty` | An optional `Boolean` to suppress errors when knowingly passing `null`, `undefined`, or `''`, defaults to `false` |
 
 Note that `interval` does not recompute the value of the helper parameters, unless it is
 part of a helper that *is* a value in which case it is useful for "live" updating as time elapses.
@@ -414,7 +414,7 @@ export default Ember.Controller.extend({
 
 ### Global Allow Empty Dates
 
-If `null`, `undefined`, or an empty string are passed as a date to any of the moment helpers then you will get `Invalid Date` in the output.  To avoid this issue globally, you can set the option `allowEmpty` which all of the helpers respect and will result in nothing being rendered instead of `Invalid Date`.
+If `null`, `undefined`, or an empty string are passed as a date to any of the moment helpers they will raise an error. To avoid this issue globally, you can set the option `allowEmpty` which all of the helpers respect and will result in no error and nothing being rendered.
 
 ```js
 // config/environment.js
@@ -511,7 +511,7 @@ export default Ember.Route.extend({
 
 An invalid date string is being passed into momentjs and/or the [input string format](https://momentjs.com/docs/#/parsing/string-format/) was omitted.
 
-If you are knowingly passing null, undefined, or an empty string and want to ignore the output of `Invalid Date` then pass the option `allow-empty=true` to the helper (all helpers accept this property)
+If you are knowingly passing null, undefined, or an empty string and want to avoid errors then pass the option `allow-empty=true` to the helper (all helpers accept this property)
 
 ```hbs
 {{moment-format ''}}  {{!-- Invalid date --}}

--- a/addon/utils/helper-compute.js
+++ b/addon/utils/helper-compute.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { isBlank } from '@ember/utils';
 import { get } from '@ember/object';
 
@@ -20,8 +21,7 @@ export default function(cb) {
         return;
       }
 
-      /* eslint-disable no-console */
-      console.warn(`ember-moment: an empty value (null, undefined, or "") was passed to ember-moment helper`);
+      assert(`ember-moment: an empty value (null, undefined, or "") was passed to ember-moment helper`);
     }
 
     return cb.apply(this, arguments);

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
@@ -96,7 +97,11 @@ test('can be called with null using global config option', function(assert) {
 test('unable to called with null overriding global config option', function(assert) {
   assert.expect(1);
 
+  const origOnerror = Ember.onerror;
+  Ember.onerror = () => assert.ok('empty value with allow-empty=false errors');
+
   this.set('date', null);
   this.render(hbs`{{moment-to-now date allow-empty=false}}`);
-  assert.equal(this.$().text(), 'Invalid date');
+
+  Ember.onerror = origOnerror;
 });


### PR DESCRIPTION
Fixes #306 

When `allow-empty` is false, raise an error on empty input instead of just a console error.