### PR TITLE
WIP: fix Ember.computed.bool is not a function

### DIFF
--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -6,7 +6,8 @@ import { inject as service } from '@ember/service';
 export default Helper.extend({
   moment: service(),
   disableInterval: false,
-  globalAllowEmpty: computed.bool('moment.__config__.allowEmpty'),
+  globalAllowEmpty: computed('moment.__config__.allowEmpty', function()
+    {return this.get('moment.__config__.allowEmpty'); }),
   supportsGlobalAllowEmpty: true,
   localeOrTimeZoneChanged: observer('moment.locale', 'moment.timeZone', function() {
     this.recompute();


### PR DESCRIPTION
When using the moment-format helper on an ember app transpiled for the latest 2 versions of Chrome and Firefox (tested on Firefox 90.0.2), I get the following error: `Uncaught (in promise) TypeError: Ember.computed.bool is not a function` (stack trace below).

This seems to be caused by this transpiled code:

```js
  exports.default = Ember.Helper.extend({
    moment: Ember.inject.service(),
    disableInterval: false,
    globalAllowEmpty: Ember.computed.bool('moment.__config__.allowEmpty'),
    supportsGlobalAllowEmpty: true,
    localeOrTimeZoneChanged: Ember.observer('moment.locale', 'moment.timeZone', function () {
      this.recompute();
    }),
```

The source code is very similar, I believe that `computed.bool` has been deprecated and that `computed` [is now a decorator](https://api.emberjs.com/ember/release/functions/@ember%2Fobject/computed).

```
Uncaught (in promise) TypeError: Ember.computed.bool is not a function
    <anonymous> Ember
    exports loader.js:106
    _reify loader.js:143
    reify loader.js:130
    exports loader.js:104
    _reify loader.js:143
    reify loader.js:130
    exports loader.js:104
    requireModule loader.js:27
    Ember 10
    resolveComponentOrHelper opcode-compiler.js:381
    encodeOp opcode-compiler.js:2636
    pushOp opcode-compiler.js:2545
    <anonymous> opcode-compiler.js:2231
    compile opcode-compiler.js:519
    compileStatements opcode-compiler.js:2549
    maybeCompile opcode-compiler.js:2528
    compile opcode-compiler.js:2508
    compile runtime.js:6020
    <anonymous> runtime.js:2410
    evaluate runtime.js:1284
    evaluateSyscall runtime.js:5177
    evaluateInner runtime.js:5133
    evaluateOuter runtime.js:5125
    next runtime.js:6257
    _execute runtime.js:6241
    execute runtime.js:6211
    handleException runtime.js:5315
    handleException runtime.js:5551
    throw runtime.js:5246
    evaluate runtime.js:2538
    _execute runtime.js:5229
    execute runtime.js:5199
    runInTrackingTransaction validator.js:154
    execute runtime.js:5199
    rerender runtime.js:5579
    Ember 3
    inTransaction runtime.js:5019
    Ember 3
    invoke backburner.js:338
    flush backburner.js:229
    flush backburner.js:426
    _end backburner.js:960
    _boundAutorunEnd backburner.js:629
    promise callback*buildNext/< backburner.js:28
    flush Ember
    _scheduleAutorun backburner.js:1179
    _end backburner.js:970
    _boundAutorunEnd backburner.js:629
    promise callback*buildNext/< backburner.js:28
    flush Ember
    _scheduleAutorun backburner.js:1179
    _end backburner.js:970
    _boundAutorunEnd backburner.js:629
    promise callback*buildNext/< backburner.js:28
    flush Ember
    _scheduleAutorun backburner.js:1179
    _ensureInstance backburner.js:1167
    schedule backburner.js:776
    <anonymous> Ember
    fulfill rsvp.js:428
    resolve$1 rsvp.js:403
    initializePromise rsvp.js:526
    Ember 2
    initializePromise rsvp.js:520
    Promise rsvp.js:1021
    Ember 5
    invokeCallback rsvp.js:493
    publish rsvp.js:476
    <anonymous> Ember
    invoke backburner.js:338
    flush backburner.js:229
    flush backburner.js:426
    _end backburner.js:960
    _boundAutorunEnd backburner.js:629
    promise callback*buildNext/< backburner.js:28
    flush Ember
    _scheduleAutorun backburner.js:1179
    _ensureInstance backburner.js:1167
```