### PR TITLE
`MomentOverride.defaultFormat` null if not defined in config

### DIFF
--- a/app/services/moment.js
+++ b/app/services/moment.js
@@ -2,5 +2,5 @@ import MomentService from 'ember-moment/services/moment';
 import config from '../config/environment';
 
 export default class MomentOverride extends MomentService {
-  defaultFormat = config.moment.outputFormat;
+  defaultFormat = config.moment && config.moment.outputFormat || null;
 }

--- a/app/services/moment.js
+++ b/app/services/moment.js
@@ -2,5 +2,5 @@ import MomentService from 'ember-moment/services/moment';
 import config from '../config/environment';
 
 export default class MomentOverride extends MomentService {
-  defaultFormat = config.moment && config.moment.outputFormat || null;
+  defaultFormat = (config.moment && config.moment.outputFormat) || null;
 }


### PR DESCRIPTION
Fixes https://github.com/adopted-ember-addons/ember-moment/issues/362

Current implementation throws `TypeError` for `undefined` if `config.moment.outputFormat` is not specified.

- checks for presence of `config.moment` and `config.moment.outputFormat`
  - set value if present, fall back to `null` otherwise