### PR TITLE
Set `MomentOverride.defaultFormat` to ISO 8601 format if not defined in config

### DIFF
--- a/app/services/moment.js
+++ b/app/services/moment.js
@@ -2,5 +2,5 @@ import MomentService from 'ember-moment/services/moment';
 import config from '../config/environment';
 
 export default class MomentOverride extends MomentService {
-  defaultFormat = config.moment.outputFormat;
+  defaultFormat = (config.moment && config.moment.outputFormat) ?? 'YYYY-MM-DDTHH:mm:ssZ';
 }

--- a/app/services/moment.js
+++ b/app/services/moment.js
@@ -2,5 +2,6 @@ import MomentService from 'ember-moment/services/moment';
 import config from '../config/environment';
 
 export default class MomentOverride extends MomentService {
-  defaultFormat = (config.moment && config.moment.outputFormat) ?? 'YYYY-MM-DDTHH:mm:ssZ';
+  defaultFormat =
+    (config.moment && config.moment.outputFormat) ?? 'YYYY-MM-DDTHH:mm:ssZ';
 }


### PR DESCRIPTION
Fixes #362

Improves PR #363 with fall back to moment.js default format (ISO 8601) if no value is set in configuration