### PR TITLE
Readd `repository` to root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "repository": "",
+  "repository": "https://github.com/adopted-ember-addons/ember-moment.git",
   "license": "MIT",
   "author": "",
   "scripts": {


### PR DESCRIPTION
This should fix `release-plan`.
It was a incident while v2 addon migration #411